### PR TITLE
Fix enum error

### DIFF
--- a/paperless.py
+++ b/paperless.py
@@ -24,10 +24,10 @@ SERVICE_NAME = 'com.nelatmani.paperless'
 
 
 class PaperlessStatus(enum.Enum):
-    OK = 0,
-    ERROR_CREDENTIAL_INVALID = enum.auto(),
-    ERROR_CREDENTIAL_NOT_FOUND = enum.auto(),
-    ERROR_SEARCH_FAILED = enum.auto(),
+    OK = 0
+    ERROR_CREDENTIAL_INVALID = enum.auto()
+    ERROR_CREDENTIAL_NOT_FOUND = enum.auto()
+    ERROR_SEARCH_FAILED = enum.auto()
     ERROR_INVALID_ARGUMENT = enum.auto()
 
 


### PR DESCRIPTION
`OK = 0,` is interpreted as `OK = (0,)`, which is a tuple that `enum.auto()` can't increment.

As shown [in the documentation](https://docs.python.org/3/library/enum.html) there's no need for a comma at the end of every line.